### PR TITLE
Updated Workflows to use Latest Meta version

### DIFF
--- a/.github/workflows/compare-to-meta.yaml
+++ b/.github/workflows/compare-to-meta.yaml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   compare:
-    uses: Nexus-Mods/NexusMods.App.Meta/.github/workflows/compare-to-meta.yaml@fc9c9eae43a7c70eaa4d66b3717cd9cd35cc2bbb
+    uses: Nexus-Mods/NexusMods.App.Meta/.github/workflows/compare-to-meta.yaml@main

--- a/.github/workflows/mkdocs-build-and-deploy.yaml
+++ b/.github/workflows/mkdocs-build-and-deploy.yaml
@@ -19,4 +19,4 @@ jobs:
       contents: read
       pages: write
       id-token: write
-    uses: Nexus-Mods/NexusMods.App.Meta/.github/workflows/mkdocs-build-and-deploy.yaml@4dd8819de8ff3d41fb13f1118cdcb28cbfb830cc
+    uses: Nexus-Mods/NexusMods.App.Meta/.github/workflows/mkdocs-build-and-deploy.yaml@main

--- a/.github/workflows/publish-nuget-packages.yaml
+++ b/.github/workflows/publish-nuget-packages.yaml
@@ -22,7 +22,7 @@ jobs:
 
   publish:
     needs: get-version
-    uses: Nexus-Mods/NexusMods.App.Meta/.github/workflows/publish-nuget-packages.yaml@728da43cdc13ef02e6bf9899503c2f7e707164f1
+    uses: Nexus-Mods/NexusMods.App.Meta/.github/workflows/publish-nuget-packages.yaml@main
     with:
       version: ${{ needs.get-version.outputs.version }}
       use-nuget: true

--- a/.github/workflows/update-from-meta.yaml
+++ b/.github/workflows/update-from-meta.yaml
@@ -10,4 +10,4 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    uses: Nexus-Mods/NexusMods.App.Meta/.github/workflows/update-from-meta.yaml@fc9c9eae43a7c70eaa4d66b3717cd9cd35cc2bbb
+    uses: Nexus-Mods/NexusMods.App.Meta/.github/workflows/update-from-meta.yaml@main

--- a/src/NexusMods.Hashing.xxHash64/NexusMods.Hashing.xxHash64.csproj
+++ b/src/NexusMods.Hashing.xxHash64/NexusMods.Hashing.xxHash64.csproj
@@ -2,6 +2,7 @@
     <!-- NuGet Package Shared Details -->
     <PropertyGroup>
       <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net7.0</TargetFrameworks>
+      <TargetFramework></TargetFramework> <!-- This is intended, to override Directory.Build.props do not remove -->
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
       <Title>NexusMods' xxHash64 Library</Title>
       <Description>Nexus Mods' Implementation of the xxHash64 algorithm.</Description>


### PR DESCRIPTION
# Summary

This PR updates our CI/CD workflows to reference the `main` branch of https://github.com/Nexus-Mods/NexusMods.App.Meta , rather than specific commit. 

Additionally, the main project's `.csproj` file has been altered to override the `TargetFramework` to be empty for `xxHash`. This allows for multi-targeting compatibility with our existing workflow.

## Changes

- Updated workflow files to pull from the `main` branch in `https://github.com/Nexus-Mods/NexusMods.App.Meta`.
- Modified `.csproj` file to set `TargetFramework` to an empty value, enabling multi-targeting.

## Dependencies

Do not merge this before [NexusMods.App.Meta/pull/9](https://github.com/Nexus-Mods/NexusMods.App.Meta/pull/9), because the package should be released as Release, not Debug.