### PR TITLE
Changed: Made XxHash64Algorithm usage less error prone.

### DIFF
--- a/src/NexusMods.Hashing.xxHash64.Benchmarks/HashRandomDataBench.cs
+++ b/src/NexusMods.Hashing.xxHash64.Benchmarks/HashRandomDataBench.cs
@@ -23,11 +23,7 @@ public class HashRandomDataBench
     public int Size { get; set; }
 
     [Benchmark]
-    public ulong NexusHash()
-    {
-        var algo = new XxHash64Algorithm(0);
-        return algo.HashBytes(_data.AsSpan()[..Size]);
-    }
+    public ulong NexusHash() => XxHash64Algorithm.HashBytes(_data.AsSpan()[..Size]);
 
     [Benchmark]
     public unsafe ulong ExtensionsHashingBench()

--- a/src/NexusMods.Hashing.xxHash64.Benchmarks/Program.cs
+++ b/src/NexusMods.Hashing.xxHash64.Benchmarks/Program.cs
@@ -1,6 +1,7 @@
 ﻿// See https://aka.ms/new-console-template for more information
 
 using BenchmarkDotNet.Running;
+using NexusMods.Hashing.xxHash64;
 using NexusMods.Hashing.xxHash64.Benchmarks;
 
 BenchmarkRunner.Run<HashRandomDataBench>();

--- a/src/NexusMods.Hashing.xxHash64.Benchmarks/Program.cs
+++ b/src/NexusMods.Hashing.xxHash64.Benchmarks/Program.cs
@@ -1,7 +1,6 @@
 ﻿// See https://aka.ms/new-console-template for more information
 
 using BenchmarkDotNet.Running;
-using NexusMods.Hashing.xxHash64;
 using NexusMods.Hashing.xxHash64.Benchmarks;
 
 BenchmarkRunner.Run<HashRandomDataBench>();

--- a/src/NexusMods.Hashing.xxHash64/SpanExtensions.cs
+++ b/src/NexusMods.Hashing.xxHash64/SpanExtensions.cs
@@ -23,11 +23,7 @@ public static class SpanExtensions
     /// </summary>
     /// <param name="data">The data to hash.</param>
     /// <returns>Hash for the given data.</returns>
-    public static Hash XxHash64(this ReadOnlySpan<byte> data)
-    {
-        var algo = new XxHash64Algorithm(0);
-        return Hash.From(algo.HashBytes(data));
-    }
+    public static Hash XxHash64(this ReadOnlySpan<byte> data) => Hash.From(XxHash64Algorithm.HashBytes(data));
 
     /// <summary>
     /// Hashes the given <see cref="Memory{T}"/> of bytes using xxHash64.

--- a/src/NexusMods.Hashing.xxHash64/XxHash64Algorithm.cs
+++ b/src/NexusMods.Hashing.xxHash64/XxHash64Algorithm.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
 using NexusMods.Hashing.xxHash64.Utilities;
 using static System.Numerics.BitOperations;
 
@@ -62,6 +63,7 @@ public struct XxHash64Algorithm
     /// <summary>
     /// Creates a new implementation of the XxHash64 hasher with a default seed of 0.
     /// </summary>
+    [PublicAPI]
     public XxHash64Algorithm() : this(0) { }
 
     /// <summary>

--- a/src/NexusMods.Hashing.xxHash64/XxHash64Algorithm.cs
+++ b/src/NexusMods.Hashing.xxHash64/XxHash64Algorithm.cs
@@ -48,7 +48,7 @@ public struct XxHash64Algorithm
     /// <summary>
     /// Creates a new implementation of the XxHash64 hasher.
     /// </summary>
-    /// <param name="seed"></param>
+    /// <param name="seed">The seed for the hashing function.</param>
     public XxHash64Algorithm(ulong seed)
     {
         _seed = seed;
@@ -60,21 +60,28 @@ public struct XxHash64Algorithm
     }
 
     /// <summary>
+    /// Creates a new implementation of the XxHash64 hasher with a default seed of 0.
+    /// </summary>
+    public XxHash64Algorithm() : this(0) { }
+
+    /// <summary>
     /// Hashes the given span of bytes.
     /// </summary>
     /// <param name="data">The complete data to hash.</param>
+    /// <param name="seed">The seed for the hash.</param>
     /// <returns>Hash for the given bytes.</returns>
     /// <remarks>
     ///     Assumes the given bytes form a complete object you want to hash.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ulong HashBytes(ReadOnlySpan<byte> data)
+    public static ulong HashBytes(ReadOnlySpan<byte> data, ulong seed = 0)
     {
+        var hash = new XxHash64Algorithm(seed);
         var initialSize = (data.Length >> 5) << 5;
         if (initialSize > 0)
-            TransformByteGroupsInternal(data[..initialSize]);
+            hash.TransformByteGroupsInternal(data[..initialSize]);
 
-        return FinalizeHashValueInternal(data[initialSize..]);
+        return hash.FinalizeHashValueInternal(data[initialSize..]);
     }
 
     /// <summary>

--- a/tests/NexusMods.Hashing.xxHash64.Tests/StreamExtensionTests.cs
+++ b/tests/NexusMods.Hashing.xxHash64.Tests/StreamExtensionTests.cs
@@ -1,7 +1,3 @@
-using System.Buffers.Binary;
-using System.IO.Hashing;
-using FluentAssertions;
-
 namespace NexusMods.Hashing.xxHash64.Tests;
 
 public class StreamExtensionTests


### PR DESCRIPTION
This PR makes a small change to our implementation of `XxHash64Algorithm`, aiming to make its usage less error prone.

Namely, it does the following:

- HashBytes is now exposed via a `static` method to ensure the algorithm is seeded.
- Creating `XxHashAlgorithm` parameterless will now correctly seed the value.

Note: This is an API breaking change and requires a new major verison.

## Example Cases

✅ This now produces valid result (previously this produced invalid hashes)
```csharp
XxHash64Algorithm hash = new();
hash.TransformByteGroupsInternal(someData);
```

```csharp
var hash = new XxHash64Algorithm().HashBytes(someData);
// Note this got changed to XxHash64Algorithm.HashBytes(someData);
```

✅ We can't use `XxHash64Algorithm` on stack without properly initializing it now
```csharp
XxHash64Algorithm hash;
hash.TransformByteGroupsInternal(someData); // ERROR. hash is uninitialized
```

👎 Unfortunately cases which use zero initialization for structs will still produce invalid results.

Due to how .NET is designed... (back compat concerns)

```csharp
class SomeClass
{
    XxHash64Algorithm _hash;
}

// Calling `new SomeClass()`, will zero initialize `_hash`, leading to incorrect seeding.
``` 

```csharp
XxHash64Algorithm _hash  = default;
// Initializing as 'default' in .NET zeroes a struct.
``` 

👍 But at least for the common use case of hashing an in-memory span, that's no longer a concern, only for streaming hashing.