### PR TITLE
Replace Vogen with TransparentValueObjects

### DIFF
--- a/.github/workflows/dotnet-build-and-test.yaml
+++ b/.github/workflows/dotnet-build-and-test.yaml
@@ -26,11 +26,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: "recursive"
-
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '8.0.6'
-
+          
       - name: Print debug info
         run: dotnet --info
 

--- a/.github/workflows/dotnet-build-and-test.yaml
+++ b/.github/workflows/dotnet-build-and-test.yaml
@@ -27,9 +27,9 @@ jobs:
         with:
           submodules: "recursive"
 
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '8.0.6'
 
       - name: Print debug info
         run: dotnet --info

--- a/src/NexusMods.Hashing.xxHash64.Benchmarks/NexusMods.Hashing.xxHash64.Benchmarks.csproj
+++ b/src/NexusMods.Hashing.xxHash64.Benchmarks/NexusMods.Hashing.xxHash64.Benchmarks.csproj
@@ -13,8 +13,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.13.7" />
-      <PackageReference Include="System.IO.Hashing" Version="7.0.0" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+      <PackageReference Include="System.IO.Hashing" Version="9.0.0-preview.3.24172.9" />
+      <PackageReference Update="JetBrains.Annotations" Version="2023.3.0" />
     </ItemGroup>
 
 </Project>

--- a/src/NexusMods.Hashing.xxHash64.Paths/NexusMods.Hashing.xxHash64.Paths.csproj
+++ b/src/NexusMods.Hashing.xxHash64.Paths/NexusMods.Hashing.xxHash64.Paths.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NexusMods.Paths" Version="0.9.1" />
+        <PackageReference Include="NexusMods.Paths" Version="0.9.5" />
         <PackageReference Include="TransparentValueObjects" Version="1.0.1" />
         <PackageReference Update="JetBrains.Annotations" Version="2023.3.0" />
     </ItemGroup>

--- a/src/NexusMods.Hashing.xxHash64.Paths/NexusMods.Hashing.xxHash64.Paths.csproj
+++ b/src/NexusMods.Hashing.xxHash64.Paths/NexusMods.Hashing.xxHash64.Paths.csproj
@@ -12,8 +12,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NexusMods.Paths" Version="0.1.3"/>
-        <PackageReference Include="Vogen" Version="3.0.20"/>
+        <PackageReference Include="NexusMods.Paths" Version="0.9.1" />
+        <PackageReference Include="TransparentValueObjects" Version="1.0.1" />
+        <PackageReference Update="JetBrains.Annotations" Version="2023.3.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NexusMods.Hashing.xxHash64/Hash.cs
+++ b/src/NexusMods.Hashing.xxHash64/Hash.cs
@@ -1,22 +1,15 @@
 using System;
 using System.Buffers.Binary;
 using JetBrains.Annotations;
-using Vogen;
+using TransparentValueObjects;
 
 namespace NexusMods.Hashing.xxHash64;
 
 /// <summary>
 /// Named object for an individual hash.
 /// </summary>
-[ValueObject(typeof(ulong),
-    conversions:
-#if NETCOREAPP3_1_OR_GREATER
-    Conversions.Default
-#else
-    Conversions.TypeConverter
-#endif
-)]
 [PublicAPI]
+[ValueObject<ulong>]
 public readonly partial struct Hash
 {
     /// <summary>
@@ -66,7 +59,7 @@ public readonly partial struct Hash
     public string ToHex()
     {
         Span<byte> buffer = stackalloc byte[8];
-        BinaryPrimitives.WriteUInt64BigEndian(buffer, _value);
+        BinaryPrimitives.WriteUInt64BigEndian(buffer, Value);
         return ((ReadOnlySpan<byte>)buffer).ToHex();
     }
 

--- a/src/NexusMods.Hashing.xxHash64/NexusMods.Hashing.xxHash64.csproj
+++ b/src/NexusMods.Hashing.xxHash64/NexusMods.Hashing.xxHash64.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <!-- NuGet Package Shared Details -->
     <PropertyGroup>
-      <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net7.0</TargetFrameworks>
-      <TargetFramework></TargetFramework> <!-- This is intended, to override Directory.Build.props do not remove -->
+      <TargetFramework>net7.0</TargetFramework>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
       <Title>NexusMods' xxHash64 Library</Title>
       <Description>Nexus Mods' Implementation of the xxHash64 algorithm.</Description>
@@ -13,12 +12,9 @@
       <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="PolySharp" Version="1.13.1">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
       <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-      <PackageReference Include="Vogen" Version="3.0.20" />
+      <PackageReference Include="TransparentValueObjects" Version="1.0.1" />
+      <PackageReference Update="JetBrains.Annotations" Version="2023.3.0" />
     </ItemGroup>
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 </Project>

--- a/tests/NexusMods.Hashing.xxHash64.Paths.Tests/NexusMods.Hashing.xxHash64.Paths.Tests.csproj
+++ b/tests/NexusMods.Hashing.xxHash64.Paths.Tests/NexusMods.Hashing.xxHash64.Paths.Tests.csproj
@@ -12,10 +12,6 @@
     <ItemGroup>
       <PackageReference Include="System.IO.Hashing" Version="9.0.0-preview.3.24172.9" />
       <PackageReference Update="JetBrains.Annotations" Version="2023.3.0" />
-      <PackageReference Update="Moq" Version="4.20.70" />
-      <PackageReference Update="AutoFixture" Version="5.0.0-preview0010" />
-      <PackageReference Update="AutoFixture.AutoMoq" Version="5.0.0-preview0010" />
-      <PackageReference Update="AutoFixture.Xunit2" Version="5.0.0-preview0010" />
       <PackageReference Update="FluentAssertions" Version="7.0.0-alpha.3" />
       <PackageReference Update="FluentAssertions.OneOf" Version="0.0.6-beta01" />
       <PackageReference Update="FluentAssertions.Analyzers" Version="0.31.0">

--- a/tests/NexusMods.Hashing.xxHash64.Paths.Tests/NexusMods.Hashing.xxHash64.Paths.Tests.csproj
+++ b/tests/NexusMods.Hashing.xxHash64.Paths.Tests/NexusMods.Hashing.xxHash64.Paths.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <EnableXunitDependencyInjectionDefaultTestFrameworkAttribute>false</EnableXunitDependencyInjectionDefaultTestFrameworkAttribute>
     </PropertyGroup>
 
@@ -10,7 +10,36 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.IO.Hashing" Version="7.0.0" />
+      <PackageReference Include="System.IO.Hashing" Version="9.0.0-preview.3.24172.9" />
+      <PackageReference Update="JetBrains.Annotations" Version="2023.3.0" />
+      <PackageReference Update="Moq" Version="4.20.70" />
+      <PackageReference Update="AutoFixture" Version="5.0.0-preview0010" />
+      <PackageReference Update="AutoFixture.AutoMoq" Version="5.0.0-preview0010" />
+      <PackageReference Update="AutoFixture.Xunit2" Version="5.0.0-preview0010" />
+      <PackageReference Update="FluentAssertions" Version="7.0.0-alpha.3" />
+      <PackageReference Update="FluentAssertions.OneOf" Version="0.0.6-beta01" />
+      <PackageReference Update="FluentAssertions.Analyzers" Version="0.31.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Update="xunit" Version="2.7.1" />
+      <PackageReference Update="xunit.runner.visualstudio" Version="2.5.8">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Update="Xunit.SkippableFact" Version="1.4.13" />
+      <PackageReference Update="Xunit.DependencyInjection" Version="9.1.0" />
+      <PackageReference Update="Xunit.DependencyInjection.Logging" Version="9.0.0" />
+      <PackageReference Update="Xunit.DependencyInjection.SkippableFact" Version="9.0.0" />
+      <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.10.0-release-24177-07" />
+      <PackageReference Update="coverlet.collector" Version="6.0.2">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Update="GitHubActionsTestLogger" Version="2.3.3">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/tests/NexusMods.Hashing.xxHash64.Tests/NexusMods.Hashing.xxHash64.Tests.csproj
+++ b/tests/NexusMods.Hashing.xxHash64.Tests/NexusMods.Hashing.xxHash64.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net7.0;netcoreapp3.1</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <EnableXunitDependencyInjectionDefaultTestFrameworkAttribute>false</EnableXunitDependencyInjectionDefaultTestFrameworkAttribute>
     </PropertyGroup>
 
@@ -9,7 +9,36 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.IO.Hashing" Version="7.0.0" />
+      <PackageReference Include="System.IO.Hashing" Version="9.0.0-preview.3.24172.9" />
+      <PackageReference Update="JetBrains.Annotations" Version="2023.3.0" />
+      <PackageReference Update="Moq" Version="4.20.70" />
+      <PackageReference Update="AutoFixture" Version="5.0.0-preview0010" />
+      <PackageReference Update="AutoFixture.AutoMoq" Version="5.0.0-preview0010" />
+      <PackageReference Update="AutoFixture.Xunit2" Version="5.0.0-preview0010" />
+      <PackageReference Update="FluentAssertions" Version="7.0.0-alpha.3" />
+      <PackageReference Update="FluentAssertions.OneOf" Version="0.0.6-beta01" />
+      <PackageReference Update="FluentAssertions.Analyzers" Version="0.31.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Update="xunit" Version="2.7.1" />
+      <PackageReference Update="xunit.runner.visualstudio" Version="2.5.8">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Update="Xunit.SkippableFact" Version="1.4.13" />
+      <PackageReference Update="Xunit.DependencyInjection" Version="9.1.0" />
+      <PackageReference Update="Xunit.DependencyInjection.Logging" Version="9.0.0" />
+      <PackageReference Update="Xunit.DependencyInjection.SkippableFact" Version="9.0.0" />
+      <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.10.0-release-24177-07" />
+      <PackageReference Update="coverlet.collector" Version="6.0.2">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Update="GitHubActionsTestLogger" Version="2.3.3">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/tests/NexusMods.Hashing.xxHash64.Tests/NexusMods.Hashing.xxHash64.Tests.csproj
+++ b/tests/NexusMods.Hashing.xxHash64.Tests/NexusMods.Hashing.xxHash64.Tests.csproj
@@ -11,10 +11,6 @@
     <ItemGroup>
       <PackageReference Include="System.IO.Hashing" Version="9.0.0-preview.3.24172.9" />
       <PackageReference Update="JetBrains.Annotations" Version="2023.3.0" />
-      <PackageReference Update="Moq" Version="4.20.70" />
-      <PackageReference Update="AutoFixture" Version="5.0.0-preview0010" />
-      <PackageReference Update="AutoFixture.AutoMoq" Version="5.0.0-preview0010" />
-      <PackageReference Update="AutoFixture.Xunit2" Version="5.0.0-preview0010" />
       <PackageReference Update="FluentAssertions" Version="7.0.0-alpha.3" />
       <PackageReference Update="FluentAssertions.OneOf" Version="0.0.6-beta01" />
       <PackageReference Update="FluentAssertions.Analyzers" Version="0.31.0">


### PR DESCRIPTION
Does the following: 

* Updates the tests to .NET 8.0
* Keeps the library code with .NET 7.0 because it works well enough and there's no reason to upgrade
* Removes all the other frameworks, I'd rather not have the complexity of using polyfils and having to think of how the code works on 4 different platforms
* Switches Vogen to TransparentValueObjects so we don't have Hashes that are 16 bytes wide instead of 8. 