### PR TITLE
Upgrade dependencies

### DIFF
--- a/src/NexusMods.Hashing.xxHash3.Paths/HashRelativePath.cs
+++ b/src/NexusMods.Hashing.xxHash3.Paths/HashRelativePath.cs
@@ -88,7 +88,7 @@ public class HashRelativePathConverter : JsonConverter<HashRelativePath>
         var hash = reader.GetUInt64();
         reader.Read();
 
-        var relativePath = reader.GetString()!.ToRelativePath();
+        RelativePath relativePath = reader.GetString()!;
         reader.Read();
 
         return new HashRelativePath(Hash.FromULong(hash), relativePath);

--- a/src/NexusMods.Hashing.xxHash3.Paths/NexusMods.Hashing.xxHash3.Paths.csproj
+++ b/src/NexusMods.Hashing.xxHash3.Paths/NexusMods.Hashing.xxHash3.Paths.csproj
@@ -13,8 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NexusMods.Paths" Version="0.15.0" />
-        <PackageReference Include="TransparentValueObjects" Version="1.0.2" />
+        <PackageReference Include="NexusMods.Paths" Version="0.19.1" />
         <PackageReference Update="JetBrains.Annotations" Version="2024.3.0" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     </ItemGroup>

--- a/src/NexusMods.Hashing.xxHash3/NexusMods.Hashing.xxHash3.csproj
+++ b/src/NexusMods.Hashing.xxHash3/NexusMods.Hashing.xxHash3.csproj
@@ -15,7 +15,8 @@
     <ItemGroup>
       <PackageReference Include="System.IO.Hashing" Version="9.0.0" />
       <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-      <PackageReference Include="TransparentValueObjects" Version="1.0.2" />
+        <PackageReference Include="TransparentValueObjects" Version="1.1.0" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <PackageReference Include="TransparentValueObjects.Abstractions" Version="1.1.0" />
       <PackageReference Update="JetBrains.Annotations" Version="2024.3.0" />
     </ItemGroup>
     <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />

--- a/tests/NexusMods.Hashing.xxHash3.Paths.Tests/HashRelativePathTests.cs
+++ b/tests/NexusMods.Hashing.xxHash3.Paths.Tests/HashRelativePathTests.cs
@@ -8,8 +8,8 @@ public class HashRelativePathTests
     [Fact]
     public void CanCreateAndCompareHashPaths()
     {
-        var a = new HashRelativePath((Hash)0xDEADBEEFDECAFBAD, "foo/bar.pex".ToRelativePath());
-        var b = new HashRelativePath((Hash)0x100000000000000F, "foo.pex".ToRelativePath());
+        var a = new HashRelativePath((Hash)0xDEADBEEFDECAFBAD, "foo/bar.pex");
+        var b = new HashRelativePath((Hash)0x100000000000000F, "foo.pex");
 
         a.Should().BeEquivalentTo(a);
         a.Should().BeRankedEquallyTo(a);
@@ -19,7 +19,7 @@ public class HashRelativePathTests
         (a != b).Should().BeTrue();
 
         a.Extension.Should().Be(new Extension(".pex"));
-        a.FileName.Should().Be("bar.pex".ToRelativePath());
+        a.FileName.Should().Be("bar.pex");
         a.GetHashCode().Should().Be(a.GetHashCode());
         b.GetHashCode().Should().NotBe(a.GetHashCode());
     }
@@ -27,8 +27,8 @@ public class HashRelativePathTests
     [Fact]
     public void CanConvertToString()
     {
-        var a = new HashRelativePath((Hash)0xDEADBEEFDECAFBAD, "foo/bar.pex".ToRelativePath());
-        var b = new HashRelativePath((Hash)0x100000000000000F, "foo.pex".ToRelativePath());
+        var a = new HashRelativePath((Hash)0xDEADBEEFDECAFBAD, "foo/bar.pex");
+        var b = new HashRelativePath((Hash)0x100000000000000F, "foo.pex");
 
         a.ToString().Should().Be("0xDEADBEEFDECAFBAD|foo/bar.pex");
         b.ToString().Should().Be("0x100000000000000F|foo.pex");


### PR DESCRIPTION
- Updates `TransparentValueObjects` from `1.0.2` to `1.1.0` and fixes the references
- Updates `NexusMods.Paths` from `0.15.0` to `0.19.1` and updates obsolete usages